### PR TITLE
Polymorph V2 changes

### DIFF
--- a/contracts/IPolymorphV1.sol
+++ b/contracts/IPolymorphV1.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.7.0;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+
+interface IPolymorphV1 is IERC721 {
+
+    function geneOf(uint256 tokenId) external view returns (uint256 gene);
+    function burn(uint256 tokenId) external;
+}

--- a/contracts/Polymorph.sol
+++ b/contracts/Polymorph.sol
@@ -105,8 +105,8 @@ contract Polymorph is IPolymorph, ERC721PresetMinterPauserAutoId, ReentrancyGuar
         polymorphV1Contract.burn(tokenId);
 
         totalBurnedV1 = totalBurnedV1.add(1);
-        _tokenIdTracker.increment();
         maxSupply = maxSupply.add(totalBurnedV1);
+        _tokenIdTracker.increment();
 
         uint256 newTokenId = _tokenIdTracker.current();
         _genes[newTokenId] = geneToTransfer;


### PR DESCRIPTION
This PR includes the following changes:
- Added **burnAndMintNewPolymorph** method where the user can burn his V1 Polymorph and mint a V2 Polymorph
- Added **wormholeUpdateGene** external method which is callable only by a bridge contract and can update the gene of the Polymorph (To be used with the Polygon bridge initially) 
- Fixed the wrong event where previously the old gene was emitted in place of the new one
- Added check for `msg.sender == tx.origin` inside **_beforeGenomeChange**