### PR TITLE
Remove preMint, add ERC2981 and Ownable

### DIFF
--- a/contracts/base/ERC721PresetMinterPauserAutoId.sol
+++ b/contracts/base/ERC721PresetMinterPauserAutoId.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Burnable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Pausable.sol";
+import "@openzeppelin/contracts/token/common/ERC2981.sol";
 import "./ERC721Consumable.sol";
 
 /**
@@ -30,7 +31,8 @@ contract ERC721PresetMinterPauserAutoId is
     ERC721Consumable,
     ERC721Enumerable,
     ERC721Burnable,
-    ERC721Pausable
+    ERC721Pausable,
+    ERC2981
 {
 
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
@@ -153,7 +155,8 @@ contract ERC721PresetMinterPauserAutoId is
             AccessControlEnumerable,
             ERC721,
             ERC721Consumable,
-            ERC721Enumerable
+            ERC721Enumerable,
+            ERC2981
         )
         returns (bool)
     {

--- a/contracts/base/Polymorph.sol
+++ b/contracts/base/Polymorph.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.13;
 import "./IPolymorph.sol";
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "../base/ERC721PresetMinterPauserAutoId.sol";
 import "../lib/PolymorphGeneGenerator.sol";
 import "../modifiers/DAOControlled.sol";
@@ -10,7 +11,8 @@ abstract contract Polymorph is
     IPolymorph,
     ERC721PresetMinterPauserAutoId,
     ReentrancyGuard,
-    DAOControlled
+    DAOControlled,
+    Ownable
 {
     using PolymorphGeneGenerator for PolymorphGeneGenerator.Gene;
 

--- a/contracts/mainnet/PolymorphRoot.sol
+++ b/contracts/mainnet/PolymorphRoot.sol
@@ -13,7 +13,7 @@ contract PolymorphRoot is PolymorphWithGeneChanger, IPolymorphRoot {
         string symbol;
         string baseURI;
         address payable _daoAddress;
-        uint256 premintedTokensCount;
+        uint96 _royaltyFee;
         uint256 _baseGenomeChangePrice;
         uint256 _polymorphPrice;
         uint256 _maxSupply;
@@ -35,6 +35,7 @@ contract PolymorphRoot is PolymorphWithGeneChanger, IPolymorphRoot {
     event PolymorphPriceChanged(uint256 newPolymorphPrice);
     event MaxSupplyChanged(uint256 newMaxSupply);
     event BulkBuyLimitChanged(uint256 newBulkBuyLimit);
+    event DefaultRoyaltyChanged(address newReceiver, uint96 newDefaultRoyalty);
 
     constructor(Params memory params)
         PolymorphWithGeneChanger(
@@ -58,15 +59,8 @@ contract PolymorphRoot is PolymorphWithGeneChanger, IPolymorphRoot {
 
         _tokenId = _tokenId + STARTING_TOKEN_ID;
 
-        _preMint(params.premintedTokensCount);
-    }
+        _setDefaultRoyalty(params._daoAddress, params._royaltyFee);
 
-    function _preMint(uint256 amountToMint) internal {
-        for (uint256 i = 0; i < amountToMint; i++) {
-            _tokenId++;
-            _genes[_tokenId] = geneGenerator.random();
-            _mint(_msgSender(), _tokenId);
-        }
     }
 
     function mint() public payable override nonReentrant {
@@ -200,6 +194,15 @@ contract PolymorphRoot is PolymorphWithGeneChanger, IPolymorphRoot {
         bulkBuyLimit = _bulkBuyLimit;
 
         emit BulkBuyLimitChanged(_bulkBuyLimit);
+    }
+
+    function setDefaultRoyalty(address receiver, uint96 royaltyFee)
+        external
+        onlyDAO
+    {
+        _setDefaultRoyalty(receiver, royaltyFee);
+
+        emit DefaultRoyaltyChanged(receiver, royaltyFee);
     }
 
     receive() external payable {

--- a/deployment/args/root-polymorph-args.js
+++ b/deployment/args/root-polymorph-args.js
@@ -3,7 +3,7 @@ const tokenSymbol = "MORPH";
 const metadataURI =
   "https://us-central1-polymorphmetadata.cloudfunctions.net/images-function?id=";
 const DAOAddress = "0x8FcE67537676879Bc5a1B86B403400E1614Bfce6";
-const premint = 0;
+const royaltyFee = 0;
 const geneChangePrice = ethers.utils.parseEther("0.01");
 const polymorphPrice = ethers.utils.parseEther("0.0777");
 const polymorphsLimit = 10000;
@@ -19,7 +19,7 @@ module.exports = [
     symbol: tokenSymbol,
     baseURI: metadataURI,
     _daoAddress: DAOAddress,
-    premintedTokensCount: premint,
+    _royaltyFee: royaltyFee,
     _baseGenomeChangePrice: geneChangePrice,
     _polymorphPrice: polymorphPrice,
     _maxSupply: polymorphsLimit,

--- a/deployment/root-polymorph-deploy.js
+++ b/deployment/root-polymorph-deploy.js
@@ -19,7 +19,7 @@ async function PolymorphDeploy() {
   const metadataURI =
     "https://us-central1-polymorphmetadata.cloudfunctions.net/images-function?id=";
   const DAOAddress = "0x8FcE67537676879Bc5a1B86B403400E1614Bfce6";
-  const premint = 0;
+  const royaltyFee = 0;
   const geneChangePrice = ethers.utils.parseEther("0.01");
   const polymorphPrice = ethers.utils.parseEther("0.0777");
   const polymorphsLimit = 10000;
@@ -34,7 +34,7 @@ async function PolymorphDeploy() {
     symbol: tokenSymbol,
     baseURI: metadataURI,
     _daoAddress: DAOAddress,
-    premintedTokensCount: premint,
+    _royaltyFee: royaltyFee,
     _baseGenomeChangePrice: geneChangePrice,
     _polymorphPrice: polymorphPrice,
     _maxSupply: polymorphsLimit,

--- a/test/ERC721Consumable.js
+++ b/test/ERC721Consumable.js
@@ -13,7 +13,7 @@ describe("ERC721Consumable", async () => {
     let name = "ConsumablePolymorph";
     let token = "POLY";
     let baseUri = "http://www.kekdao.com/";
-    let premintedTokensCount = 0;
+    let royaltyFee = 0;
     let totalSupply = 10000;
     let bulkBuyLimit = 20;
     let polymorphPrice = ethers.utils.parseEther("0.0777");
@@ -36,7 +36,7 @@ describe("ERC721Consumable", async () => {
             symbol: token,
             baseURI: baseUri,
             _daoAddress: approved.address,
-            premintedTokensCount: premintedTokensCount,
+            _royaltyFee: royaltyFee,
             _baseGenomeChangePrice: defaultGenomeChangePrice,
             _polymorphPrice: polymorphPrice,
             _maxSupply: totalSupply,

--- a/test/GeneFlipper.js
+++ b/test/GeneFlipper.js
@@ -12,7 +12,7 @@ describe('Gene Flipper', () => {
     let tokenName = "PolymorphWithGeneChanger"
     let token = "POLY";
     let baseUri = "http://www.kekdao.com/";
-    let premintedTokensCount = 5;
+    let royaltyFee = 0;
     let totalSupply = 10000;
     let bulkBuyLimit = 20;
     let polymorphPrice = ethers.utils.parseEther("0.0777");
@@ -35,7 +35,7 @@ describe('Gene Flipper', () => {
         symbol: token,
         baseURI: baseUri,
         _daoAddress: DAO.address,
-        premintedTokensCount: premintedTokensCount,
+        _royaltyFee: royaltyFee,
         _baseGenomeChangePrice: defaultGenomeChangePrice,
         _polymorphPrice: polymorphPrice,
         _maxSupply: totalSupply,

--- a/test/MainnetBridge.js
+++ b/test/MainnetBridge.js
@@ -12,7 +12,7 @@ describe('Polymorph Mainnet Integration', () => {
   let baseUri = "";
   let polymorphV1Address = "0x75D38741878da8520d1Ae6db298A9BD994A5D241";
   let defaultGenomeChangePrice = ethers.utils.parseEther("0.01");
-  let premintedTokensCount = 0;
+  let royaltyFee = 0;
   let polymorphPrice = ethers.utils.parseEther("0.0777");
   let totalSupply = 10000;
   let randomizeGenomePrice = ethers.utils.parseEther("0.01");
@@ -29,7 +29,7 @@ describe('Polymorph Mainnet Integration', () => {
       symbol: token,
       baseURI: baseUri,
       _daoAddress: dao.address,
-      premintedTokensCount: premintedTokensCount,
+      _royaltyFee: royaltyFee,
       _baseGenomeChangePrice: defaultGenomeChangePrice,
       _polymorphPrice: polymorphPrice,
       _maxSupply: totalSupply,

--- a/test/PolymorphRootBurnAndMint.js
+++ b/test/PolymorphRootBurnAndMint.js
@@ -11,6 +11,7 @@ describe("PolymorphRootBurnAndMint", () => {
   let token = "POLY";
   let baseUri = "http://www.kekdao.com/";
   let premintedTokensCount = 0;
+  let royaltyFee = 0;
   let totalSupply = 10000;
   let bulkBuyLimit = 20;
   let polymorphPrice = ethers.utils.parseEther("0.0777");
@@ -20,6 +21,7 @@ describe("PolymorphRootBurnAndMint", () => {
   let polymorphV1Address = "0x75D38741878da8520d1Ae6db298A9BD994A5D241";
 
   let constructorArgs;
+  let constructorArgsV2;
 
   before(async () => {
     const [user, dao, alice, bob] = await ethers.getSigners();
@@ -43,9 +45,24 @@ describe("PolymorphRootBurnAndMint", () => {
       _arweaveAssetsJSON: arweaveAssetsJSON,
       _polymorphV1Address: polymorphV1Address,
     };
+
+    constructorArgsV2 = {
+      name: name,
+      symbol: token,
+      baseURI: baseUri,
+      _daoAddress: DAO.address,
+      _royaltyFee: royaltyFee,
+      _baseGenomeChangePrice: defaultGenomeChangePrice,
+      _polymorphPrice: polymorphPrice,
+      _maxSupply: totalSupply,
+      _randomizeGenomePrice: randomizeGenomePrice,
+      _bulkBuyLimit: bulkBuyLimit,
+      _arweaveAssetsJSON: arweaveAssetsJSON,
+      _polymorphV1Address: polymorphV1Address,
+    };
     
     const PolymorphRoot = await ethers.getContractFactory("PolymorphRoot");
-    polymorphInstance = await PolymorphRoot.deploy(constructorArgs);
+    polymorphInstance = await PolymorphRoot.deploy(constructorArgsV2);
 
     console.log(`Polymorph instance deployed to: ${polymorphInstance.address}`);
   });
@@ -60,9 +77,9 @@ describe("PolymorphRootBurnAndMint", () => {
 
     v1Instance = await PolymorphV1.deploy(constructorArgs);
 
-    constructorArgs["_polymorphV1Address"] = v1Instance.address;
+    constructorArgsV2["_polymorphV1Address"] = v1Instance.address;
 
-    v2Instance = await PolymorphRoot.deploy(constructorArgs);
+    v2Instance = await PolymorphRoot.deploy(constructorArgsV2);
     const bulkBuyCount = 5;
 
     await v1Instance.bulkBuy(bulkBuyCount, {
@@ -92,9 +109,9 @@ describe("PolymorphRootBurnAndMint", () => {
 
     v1Instance = await PolymorphV1.deploy(constructorArgs);
 
-    constructorArgs["_polymorphV1Address"] = v1Instance.address;
+    constructorArgsV2["_polymorphV1Address"] = v1Instance.address;
 
-    v2Instance = await PolymorphRoot.deploy(constructorArgs);
+    v2Instance = await PolymorphRoot.deploy(constructorArgsV2);
 
     const bulkBuyCount = 5;
 


### PR DESCRIPTION
In this PR I have:
- Removed unnecessary preMint function for Polymorphs V2 contract
- Added support for ERC2981 Royalties Standard
- Added Ownable pattern